### PR TITLE
Rename Panorama -> Panoramas

### DIFF
--- a/web/panorama/datasets/panoramas/models.py
+++ b/web/panorama/datasets/panoramas/models.py
@@ -25,7 +25,7 @@ SURFACE_TYPE_CHOICES = (
 )
 
 
-class AbstractPanoramas(StatusModel):
+class AbstractPanorama(StatusModel):
     STATUS = Choices(
         "to_be_rendered",
         "rendering",
@@ -189,17 +189,17 @@ class Mission(models.Model):
     date = models.DateField(null=True)
 
 
-class Panoramas(AbstractPanoramas):
+class Panorama(AbstractPanorama):
     roll = models.FloatField()
     pitch = models.FloatField()
     heading = models.FloatField()
 
-    class Meta(AbstractPanoramas.Meta):
+    class Meta(AbstractPanorama.Meta):
         abstract = False
         db_table = "panoramas_panorama"
 
 
-class Adjacencies(AbstractPanoramas):
+class Adjacencies(AbstractPanorama):
     from_pano_id = models.CharField(max_length=37)
     from_geolocation_2d_rd = geo.PointField(dim=2, srid=28992, spatial_index=True)
 
@@ -208,7 +208,7 @@ class Adjacencies(AbstractPanoramas):
     relative_heading = models.FloatField()
     relative_elevation = models.FloatField()
 
-    class Meta(AbstractPanoramas.Meta):
+    class Meta(AbstractPanorama.Meta):
         abstract = False
         managed = False
         db_table = "panoramas_adjacencies_new"

--- a/web/panorama/datasets/panoramas/serialize/serializers.py
+++ b/web/panorama/datasets/panoramas/serialize/serializers.py
@@ -11,7 +11,7 @@ from datasets.panoramas.serialize.hal_serializer import (
     IdentityLinksField,
     HALListSerializer,
 )
-from datasets.panoramas.models import Panoramas, Adjacencies
+from datasets.panoramas.models import Panorama, Adjacencies
 
 log = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ class PanoSerializer(HALSerializer):
     geometry = fields.GeometryField(source="geolocation")
 
     class Meta(HALSerializer.Meta):
-        model = Panoramas
+        model = Panorama
         listresults_field = "panoramas"
         list_serializer_class = HALListSerializer
         exclude = (
@@ -115,5 +115,5 @@ class ThumbnailSerializer(serializers.ModelSerializer):
     url = serializers.ReadOnlyField()
 
     class Meta:
-        model = Panoramas
+        model = Panorama
         fields = ("url", "heading", "pano_id")

--- a/web/panorama/datasets/panoramas/tests/factories.py
+++ b/web/panorama/datasets/panoramas/tests/factories.py
@@ -5,7 +5,7 @@ from .. import models
 
 class PanoramaFactory(factory.django.DjangoModelFactory):
     class Meta:
-        model = models.Panoramas
+        model = models.Panorama
 
 
 class TrajectFactory(factory.django.DjangoModelFactory):

--- a/web/panorama/datasets/panoramas/tests/test_model.py
+++ b/web/panorama/datasets/panoramas/tests/test_model.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from django.contrib.gis.geos import Point
 from django.conf import settings
 
-from datasets.panoramas.models import Panoramas
+from datasets.panoramas.models import Panorama
 
 
 class TestModel(TestCase):
@@ -25,7 +25,7 @@ class TestModel(TestCase):
             ),
         ]
         for c in cases:
-            p = Panoramas(path=c[0], filename=c[1], geolocation=Point(1, 1, 1))
+            p = Panorama(path=c[0], filename=c[1], geolocation=Point(1, 1, 1))
             self.assertEqual(c[2], p.equirectangular_full)
             self.assertEqual(c[3], p.equirectangular_medium)
             self.assertEqual(c[4], p.equirectangular_small)
@@ -43,5 +43,5 @@ class TestModel(TestCase):
         ]
 
         for c in cases:
-            p = Panoramas(path=c[0], filename=c[1], geolocation=Point(1, 1, 1))
+            p = Panorama(path=c[0], filename=c[1], geolocation=Point(1, 1, 1))
             self.assertEqual(c[2], p.get_raw_image_objectstore_id())

--- a/web/panorama/panorama/management/commands/import_increments.py
+++ b/web/panorama/panorama/management/commands/import_increments.py
@@ -5,7 +5,7 @@ import sys
 
 from django.core.management import BaseCommand
 
-from datasets.panoramas.models import Panoramas
+from datasets.panoramas.models import Panorama
 from panorama.etl.batch_import import rebuild_mission, import_mission_metadata
 from panorama.etl.check_objectstore import set_uptodate_info
 from panorama.etl.db_actions import dump_mission, restore_all
@@ -130,7 +130,7 @@ class Command(BaseCommand):
 
     @staticmethod
     def _set_env_for_swarm_start():
-        to_process_count = Panoramas.objects.count() - Panoramas.done.count()
+        to_process_count = Panorama.objects.count() - Panorama.done.count()
         if to_process_count > 2000:
             os.environ["START_SWARM"] = "1"
             os.environ["PANOS_TO_PROCESS"] = str(to_process_count)

--- a/web/panorama/panorama/settings.py
+++ b/web/panorama/panorama/settings.py
@@ -83,7 +83,7 @@ USE_TZ = True
 STATIC_URL = "/panorama/static/"
 STATIC_ROOT = os.path.abspath(os.path.join(BASE_DIR, "..", "static"))
 
-HEALTH_MODEL = "panoramas.Panoramas"
+HEALTH_MODEL = "panoramas.Panorama"
 
 SENTRY_DSN = os.getenv("SENTRY_DSN")
 if SENTRY_DSN:

--- a/web/panorama/panorama/tests/test_api_base.py
+++ b/web/panorama/panorama/tests/test_api_base.py
@@ -9,7 +9,7 @@ import factory.fuzzy
 from rest_framework.test import APITestCase
 
 # Project
-from datasets.panoramas.models import Panoramas
+from datasets.panoramas.models import Panorama
 from datasets.panoramas.tests import factories
 
 
@@ -20,7 +20,7 @@ class PanoramaApiTest(APITestCase):
         # Adding locations
         factories.PanoramaFactory.create(
             pano_id="PANO_1_2014",
-            status=Panoramas.STATUS.done,
+            status=Panorama.STATUS.done,
             timestamp=factory.fuzzy.FuzzyDateTime(
                 datetime.datetime(2014, 1, 1, tzinfo=UTC_TZ), force_year=2014
             ),
@@ -37,7 +37,7 @@ class PanoramaApiTest(APITestCase):
         )
         factories.PanoramaFactory.create(
             pano_id="PANO_2_2014_CLOSE",
-            status=Panoramas.STATUS.done,
+            status=Panorama.STATUS.done,
             timestamp=factory.fuzzy.FuzzyDateTime(
                 datetime.datetime(2014, 1, 1, tzinfo=UTC_TZ), force_year=2014
             ),
@@ -54,7 +54,7 @@ class PanoramaApiTest(APITestCase):
         )
         factories.PanoramaFactory.create(
             pano_id="PANO_3_2015_CLOSE",
-            status=Panoramas.STATUS.done,
+            status=Panorama.STATUS.done,
             timestamp=factory.fuzzy.FuzzyDateTime(
                 datetime.datetime(2015, 1, 1, tzinfo=UTC_TZ), force_year=2015
             ),
@@ -71,7 +71,7 @@ class PanoramaApiTest(APITestCase):
         )
         factories.PanoramaFactory.create(
             pano_id="PANO_5_2014_CLOSE_BUT_NO_CIGAR",
-            status=Panoramas.STATUS.detected,
+            status=Panorama.STATUS.detected,
             timestamp=factory.fuzzy.FuzzyDateTime(
                 datetime.datetime(2014, 1, 1, tzinfo=UTC_TZ), force_year=2014
             ),
@@ -88,7 +88,7 @@ class PanoramaApiTest(APITestCase):
         )
         factories.PanoramaFactory.create(
             pano_id="PANO_5_2015_CLOSE_BUT_NO_CIGAR",
-            status=Panoramas.STATUS.to_be_rendered,
+            status=Panorama.STATUS.to_be_rendered,
             timestamp=factory.fuzzy.FuzzyDateTime(
                 datetime.datetime(2015, 1, 1, tzinfo=UTC_TZ), force_year=2015
             ),
@@ -105,7 +105,7 @@ class PanoramaApiTest(APITestCase):
         )
         factories.PanoramaFactory.create(
             pano_id="PANO_6_2016_CLOSE",
-            status=Panoramas.STATUS.done,
+            status=Panorama.STATUS.done,
             timestamp=datetime.datetime(2016, 5, 5, tzinfo=UTC_TZ),
             filename=factory.fuzzy.FuzzyText(length=30),
             path=factory.fuzzy.FuzzyText(length=30),
@@ -120,7 +120,7 @@ class PanoramaApiTest(APITestCase):
         )
         factories.PanoramaFactory.create(
             pano_id="PANO_7_2016_CLOSE_BUT_NO_CIGAR",
-            status=Panoramas.STATUS.done,
+            status=Panorama.STATUS.done,
             timestamp=datetime.datetime(2016, 5, 5, tzinfo=UTC_TZ),
             filename=factory.fuzzy.FuzzyText(length=30),
             path=factory.fuzzy.FuzzyText(length=30),
@@ -135,7 +135,7 @@ class PanoramaApiTest(APITestCase):
         )
         factories.PanoramaFactory.create(
             pano_id="PANO_8_2017_CLOSE",
-            status=Panoramas.STATUS.done,
+            status=Panorama.STATUS.done,
             timestamp=datetime.datetime(2017, 5, 5, tzinfo=UTC_TZ),
             filename=factory.fuzzy.FuzzyText(length=30),
             path=factory.fuzzy.FuzzyText(length=30),
@@ -150,7 +150,7 @@ class PanoramaApiTest(APITestCase):
         )
         factories.PanoramaFactory.create(
             pano_id="PANO_9_2017_CLOSE_BUT_NO_CIGAR",
-            status=Panoramas.STATUS.done,
+            status=Panorama.STATUS.done,
             timestamp=datetime.datetime(2017, 5, 5, tzinfo=UTC_TZ),
             filename=factory.fuzzy.FuzzyText(length=30),
             path=factory.fuzzy.FuzzyText(length=30),
@@ -165,7 +165,7 @@ class PanoramaApiTest(APITestCase):
         )
         factories.PanoramaFactory.create(
             pano_id="PANO_WOZ_2018",
-            status=Panoramas.STATUS.done,
+            status=Panorama.STATUS.done,
             timestamp=datetime.datetime(2018, 5, 5, tzinfo=UTC_TZ),
             filename=factory.fuzzy.FuzzyText(length=30),
             path=factory.fuzzy.FuzzyText(length=30),

--- a/web/panorama/panorama/tests/test_api_thumbnail.py
+++ b/web/panorama/panorama/tests/test_api_thumbnail.py
@@ -9,7 +9,7 @@ import factory.fuzzy
 
 # Project
 from .test_api_base import PanoramaApiTest
-from datasets.panoramas.models import Panoramas
+from datasets.panoramas.models import Panorama
 from datasets.panoramas.tests import factories
 
 

--- a/web/panorama/panorama/transform/tests/test_transformer.py
+++ b/web/panorama/panorama/transform/tests/test_transformer.py
@@ -10,7 +10,7 @@ import factory.fuzzy
 
 # Project
 from datasets.panoramas.tests import factories
-from datasets.panoramas.models import Panoramas
+from datasets.panoramas.models import Panorama
 
 
 class TestTransformer(TestCase):
@@ -19,7 +19,7 @@ class TestTransformer(TestCase):
         super().setUpClass()
 
         try:
-            Panoramas.objects.filter(pano_id="TMX7315120208-000073_pano_0004_000087")[0]
+            Panorama.objects.filter(pano_id="TMX7315120208-000073_pano_0004_000087")[0]
         except IndexError:
             factories.PanoramaFactory.create(
                 pano_id="TMX7315120208-000073_pano_0004_000087",
@@ -38,7 +38,7 @@ class TestTransformer(TestCase):
             )
 
         try:
-            Panoramas.objects.filter(pano_id="TMX7315120208-000067_pano_0011_000463")[0]
+            Panorama.objects.filter(pano_id="TMX7315120208-000067_pano_0011_000463")[0]
         except IndexError:
             factories.PanoramaFactory.create(
                 pano_id="TMX7315120208-000067_pano_0011_000463",
@@ -57,10 +57,10 @@ class TestTransformer(TestCase):
             )
 
         cls.images = [
-            Panoramas.objects.filter(pano_id="TMX7315120208-000073_pano_0004_000087")[
+            Panorama.objects.filter(pano_id="TMX7315120208-000073_pano_0004_000087")[
                 0
             ],
-            Panoramas.objects.filter(pano_id="TMX7315120208-000067_pano_0011_000463")[
+            Panorama.objects.filter(pano_id="TMX7315120208-000067_pano_0011_000463")[
                 0
             ],
         ]

--- a/web/panorama/panorama/transform/thumbnail.py
+++ b/web/panorama/panorama/transform/thumbnail.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from PIL.Image import BICUBIC
 
-from datasets.panoramas.models import Panoramas
+from datasets.panoramas.models import Panorama
 from panorama.shared.object_store import ObjectStore
 from .transformer import PANO_FOV, PANO_HORIZON, PANO_ASPECT
 from .utils_img_file import get_panorama_image
@@ -56,7 +56,7 @@ class Thumbnail(object):
     Thambnail for a panorama
     """
 
-    def __init__(self, panorama: Panoramas):
+    def __init__(self, panorama: Panorama):
         self.panorama = panorama
 
     def get_image(

--- a/web/panorama/panorama/urls.py
+++ b/web/panorama/panorama/urls.py
@@ -10,7 +10,7 @@ from rest_framework_swagger.renderers import OpenAPIRenderer
 from rest_framework_swagger.renderers import SwaggerUIRenderer
 
 from .view_imgs import ThumbnailViewSet
-from .views import PanoramasViewSet
+from .views import PanoramaViewSet
 
 
 class PanoramaView(routers.APIRootView):
@@ -35,7 +35,7 @@ class PanoramaRouter(routers.DefaultRouter):
 
 panorama = PanoramaRouter()
 panorama.register("thumbnail", ThumbnailViewSet, basename="thumbnail")
-panorama.register("panoramas", PanoramasViewSet, basename="panoramas")
+panorama.register("panoramas", PanoramaViewSet, basename="panoramas")
 
 APIS = [re_path(r"^panorama/", include(panorama.urls))]
 

--- a/web/panorama/panorama/view_imgs.py
+++ b/web/panorama/panorama/view_imgs.py
@@ -8,10 +8,10 @@ from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
 
-from datasets.panoramas.models import Panoramas
+from datasets.panoramas.models import Panorama
 from datasets.panoramas.serialize.serializers import ThumbnailSerializer
 from panorama.transform.thumbnail import Thumbnail
-from panorama.views import PanoramasViewSet
+from panorama.views import PanoramaViewSet
 from .queryparam_utils import get_float_value, get_int_value, get_request_coord
 
 
@@ -27,7 +27,7 @@ class ImgRenderer(renderers.BaseRenderer):
         pass
 
 
-class ThumbnailViewSet(PanoramasViewSet):
+class ThumbnailViewSet(PanoramaViewSet):
 
     """
     View to retrieve thumbs of a panorama
@@ -96,7 +96,7 @@ class ThumbnailViewSet(PanoramasViewSet):
         if "radius" not in request._request.GET:
             request._request.GET["radius"] = "20"
 
-        pano_view = PanoramasViewSet.as_view({"get": "list"})
+        pano_view = PanoramaViewSet.as_view({"get": "list"})
         pano_resultset = pano_view(request._request, **kwargs)
 
         if pano_resultset.status_code != 200:
@@ -172,7 +172,7 @@ class ThumbnailViewSet(PanoramasViewSet):
         target_horizon = get_float_value(request, "horizon", default=0.3, lower=0.0, upper=1.0)
         target_aspect = get_float_value(request, "aspect", default=1.5, lower=1.0)
 
-        pano = get_object_or_404(Panoramas, pano_id=pano_id)
+        pano = get_object_or_404(Panorama, pano_id=pano_id)
         thumb = Thumbnail(pano)
         thumb_img = thumb.get_image(
             target_width=target_width,

--- a/web/panorama/panorama/views.py
+++ b/web/panorama/panorama/views.py
@@ -21,7 +21,7 @@ from datasets.panoramas.serialize.hal_serializer import (
     HALPaginationEmbedded,
     simple_hal_embed,
 )
-from datasets.panoramas.models import Panoramas, Adjacencies
+from datasets.panoramas.models import Panorama, Adjacencies
 from datasets.panoramas.serialize.serializers import (
     PanoSerializer,
     AdjacentPanoSerializer,
@@ -82,7 +82,7 @@ class PanoramaFilter(FilterSet):
     tags = filters.CharFilter(method="tags_filter", label="Tags")
 
     class Meta(object):
-        model = Panoramas
+        model = Panorama
 
         # when adding new filter-fields remember to add them as well to the inner-query `exists` in
         #   the method `newest_in_range_filter`
@@ -360,7 +360,7 @@ class PanoramaFilterAdjacent(PanoramaFilter):
         ).filter(within=True)
 
 
-class PanoramasViewSet(rest.DatapuntViewSet):
+class PanoramaViewSet(rest.DatapuntViewSet):
     """
     Parameters:
 
@@ -376,7 +376,7 @@ class PanoramasViewSet(rest.DatapuntViewSet):
     """
 
     lookup_field = "pano_id"
-    queryset = Panoramas.done.all()
+    queryset = Panorama.done.all()
     serializer_detail_class = PanoSerializer
     serializer_class = PanoSerializer
     pagination_class = HALPaginationEmbedded


### PR DESCRIPTION
This is the result of

    find . -name '*.py' -exec sed -i 's/Panoramas/Panorama/g' {} \;

on the entire codebase. The reason for doing this is that `makemigrations` hasn't been run for years, and running it now will delete the Panorama table and create a new Panoramas table.

The naming of models in terms of singular/plural is inconsistent anyway, so this doesn't matter for code style.

Discovered this while working on [Amsterdam/panorama](https://github.com/Amsterdam/panorama). I'll apply the same change there.