### PR TITLE
For pg password fall back to getting it from env var

### DIFF
--- a/web/panorama/panorama/settings.py
+++ b/web/panorama/panorama/settings.py
@@ -23,7 +23,7 @@ def get_db_password(env_var_name):
         password_file_path = os.environ[env_var_name]
         return Path(password_file_path).read_text()
     except KeyError:
-        return "insecure"
+        os.getenv('DATABASE_PASSWORD', 'insecure')
 
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
On azure, pg password comes from a path in a mounted vol with secrets This is not available on cvps, so there needs to be a fallback to getting the pg password from an env. var