### PR TITLE
Set debug explicitly

### DIFF
--- a/web/panorama/panorama/settings_common.py
+++ b/web/panorama/panorama/settings_common.py
@@ -36,7 +36,7 @@ SECRET_KEY = get_path_variable("SECRET_KEY_PATH", env.get('SECRET_KEY', insecure
 #
 MINIMAL_HEALTH_CHECKS = str2bool(os.getenv("MINIMAL_HEALTH_CHECKS", "False"))
 
-DEBUG = SECRET_KEY == insecure_key
+DEBUG = env.get('DEBUG', False)
 
 ALLOWED_HOSTS = ["*"]
 


### PR DESCRIPTION
Debug was set to true when another variable was missing. In effect defaulting to an insecure configuration.