### PR TITLE
Remove drf-amsterdam

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -16,7 +16,6 @@ djangorestframework==3.15.2
 djangorestframework-csv==3.0.2
 djangorestframework-gis==1.0
 djangorestframework-xml==2.0.0
-drf-amsterdam==0.4.1
 drf-extensions==0.7.1
 drf-hal-json==0.10.0
 drf-nested-fields==0.9.5


### PR DESCRIPTION
It is in the requirements but it does not seem to be used. Package is not maintained.